### PR TITLE
Add auto-knockout Discord alerts

### DIFF
--- a/src/auto_knockout.py
+++ b/src/auto_knockout.py
@@ -24,12 +24,58 @@ class AutoKnockoutEvent:
     required_checkins: int
     checkin_count: int
     challenge_week_id: int
+    discord_id: str | None = None
     mulligan_checkin_id: int | None = None
     mulligan_day: str | None = None
+    remaining_checkin_days: tuple[str, ...] = ()
+    has_mulligan_available: bool = False
 
 
 def required_checkins_for_week(is_green_week):
     return 5 if is_green_week else 2
+
+
+def remaining_week_days(run_date, week_end):
+    days_remaining = min(max((week_end - run_date).days + 1, 0), 7)
+    return tuple(
+        (run_date + timedelta(days=day_offset)).strftime("%A")
+        for day_offset in range(days_remaining)
+    )
+
+
+def effective_remaining_week_days(remaining_checkin_days, run_day, current_day_checked_in):
+    return tuple(
+        day
+        for day in remaining_checkin_days
+        if not (current_day_checked_in and day == run_day)
+    )
+
+
+def should_send_first_no_slack_warning(challenge_week, run_date, required_checkins, checked_in_days):
+    allowed_missed_days = 7 - required_checkins
+    checked_in_days = set(checked_in_days or [])
+    prior_days = []
+    days_elapsed = min(max((run_date - challenge_week.start).days, 0), 7)
+
+    for day_offset in range(days_elapsed):
+        prior_days.append((challenge_week.start + timedelta(days=day_offset)).strftime("%A"))
+
+    missed_prior_days = [day for day in prior_days if day not in checked_in_days]
+    if len(missed_prior_days) != allowed_missed_days:
+        return False
+
+    return len(missed_prior_days) > 0 and missed_prior_days[-1] == prior_days[-1]
+
+
+def format_day_list(days):
+    days = list(days)
+    if len(days) == 0:
+        return ""
+    if len(days) == 1:
+        return days[0]
+    if len(days) == 2:
+        return f"{days[0]} and {days[1]}"
+    return f"{', '.join(days[:-1])}, and {days[-1]}"
 
 
 def first_missed_day(week_start, checked_in_days):
@@ -66,12 +112,37 @@ def get_previous_challenge_week(cur):
     return cur.fetchone()
 
 
+def get_current_challenge_week(cur):
+    cur.execute(
+        """
+        select
+            c.id as challenge_id,
+            cw.id as challenge_week_id,
+            cw.start,
+            cw."end",
+            coalesce(cw.green, false) as green,
+            cw.bye_week
+        from challenge_weeks cw
+        join challenges c on c.id = cw.challenge_id
+        where
+            (current_timestamp at time zone 'America/New_York')::date >= cw.start
+            and (current_timestamp at time zone 'America/New_York')::date <= cw."end"
+            and (current_timestamp at time zone 'America/New_York')::date >= c.start
+            and (current_timestamp at time zone 'America/New_York')::date <= c."end"
+        order by cw.start desc
+        limit 1;
+        """
+    )
+    return cur.fetchone()
+
+
 def get_participants_for_week(cur, challenge_id, challenge_week_id):
     cur.execute(
         """
         select
             ch.id,
             ch.name,
+            ch.discord_id,
             ch.tz,
             cc.mulligan,
             count(distinct c.day_of_week) filter (
@@ -92,10 +163,49 @@ def get_participants_for_week(cur, challenge_id, challenge_week_id):
             cc.challenge_id = %s
             and cc.knocked_out = false
             and coalesce(cc.tier, '') != 'T0'
-        group by ch.id, ch.name, ch.tz, cc.mulligan
+        group by ch.id, ch.name, ch.discord_id, ch.tz, cc.mulligan
         order by ch.name;
         """,
         (challenge_week_id, challenge_id),
+    )
+    return cur.fetchall()
+
+
+def get_alert_participants_for_week(cur, challenge_id, challenge_week_id, run_day):
+    cur.execute(
+        """
+        select
+            ch.id,
+            ch.name,
+            ch.discord_id,
+            ch.tz,
+            cc.mulligan,
+            count(distinct c.day_of_week) filter (
+                where c.tier != 'T0'
+            ) as checkin_count,
+            array_remove(
+                array_agg(distinct c.day_of_week) filter (
+                    where c.tier != 'T0'
+                ),
+                null
+            ) as checked_in_days,
+            coalesce(
+                bool_or(c.tier != 'T0' and c.day_of_week = %s),
+                false
+            ) as current_day_checked_in
+        from challenger_challenges cc
+        join challengers ch on ch.id = cc.challenger_id
+        left join checkins c on
+            c.challenger = ch.id
+            and c.challenge_week_id = %s
+        where
+            cc.challenge_id = %s
+            and cc.knocked_out = false
+            and coalesce(cc.tier, '') != 'T0'
+        group by ch.id, ch.name, ch.discord_id, ch.tz, cc.mulligan
+        order by ch.name;
+        """,
+        (run_day, challenge_week_id, challenge_id),
     )
     return cur.fetchall()
 
@@ -170,6 +280,7 @@ def apply_auto_knockout_for_week(cur, challenge_week, participants):
                     required_checkins=required_checkins,
                     checkin_count=checkin_count,
                     challenge_week_id=challenge_week.challenge_week_id,
+                    discord_id=participant.discord_id,
                     mulligan_checkin_id=mulligan_id,
                     mulligan_day=mulligan_day,
                 )
@@ -185,10 +296,110 @@ def apply_auto_knockout_for_week(cur, challenge_week, participants):
                     required_checkins=required_checkins,
                     checkin_count=checkin_count,
                     challenge_week_id=challenge_week.challenge_week_id,
+                    discord_id=participant.discord_id,
                 )
             )
 
     return events
+
+
+def build_auto_knockout_alerts_for_week(challenge_week, run_date, participants):
+    if challenge_week.bye_week:
+        return []
+
+    required_checkins = required_checkins_for_week(challenge_week.green)
+    remaining_days = remaining_week_days(run_date, challenge_week.end)
+    run_day = run_date.strftime("%A")
+    events = []
+
+    for participant in participants:
+        checkin_count = participant.checkin_count or 0
+        if checkin_count >= required_checkins:
+            continue
+
+        effective_remaining_days = effective_remaining_week_days(
+            remaining_days,
+            run_day,
+            participant.current_day_checked_in,
+        )
+        if len(effective_remaining_days) == 0:
+            continue
+
+        needed_checkins = required_checkins - checkin_count
+        if needed_checkins < len(effective_remaining_days):
+            continue
+
+        if not should_send_first_no_slack_warning(
+            challenge_week,
+            run_date,
+            required_checkins,
+            participant.checked_in_days,
+        ):
+            continue
+
+        events.append(
+            AutoKnockoutEvent(
+                action="warning",
+                challenge_id=challenge_week.challenge_id,
+                challenger_id=participant.id,
+                name=participant.name,
+                required_checkins=required_checkins,
+                checkin_count=checkin_count,
+                challenge_week_id=challenge_week.challenge_week_id,
+                discord_id=participant.discord_id,
+                remaining_checkin_days=effective_remaining_days,
+                has_mulligan_available=participant.mulligan is None,
+            )
+        )
+
+    return events
+
+
+def build_auto_knockout_alert_message(events):
+    warnings = [event for event in events if event.action == "warning"]
+    if len(warnings) == 0:
+        return None
+
+    lines = []
+    for event in warnings:
+        days = format_day_list(event.remaining_checkin_days)
+        consequence = (
+            "to avoid using a mulligan or being knocked out"
+            if event.has_mulligan_available
+            else "to avoid knockout"
+        )
+        lines.append(
+            f"<@{event.discord_id}> must check in on {days} {consequence}."
+        )
+
+    return "## Knockout warnings\n" + "\n".join(lines)
+
+
+def build_auto_knockout_reconciliation_message(events):
+    mulligans = [event for event in events if event.action == "mulligan"]
+    knockouts = [event for event in events if event.action == "knockout"]
+    sections = []
+
+    if mulligans:
+        lines = [
+            f"<@{event.discord_id}> was saved from knockout by their mulligan "
+            f"on {event.mulligan_day}."
+            for event in mulligans
+        ]
+        sections.append("## Mulligans used\n" + "\n".join(lines))
+
+    if knockouts:
+        lines = [
+            f"<@{event.discord_id}> has been knocked out with "
+            f"{event.checkin_count}/{event.required_checkins} T1+ check-ins this week."
+            for event in knockouts
+        ]
+        sections.append("## Knockouts\n" + "\n".join(lines))
+
+    if len(sections) == 0:
+        return None
+
+    return "\n\n".join(sections)
 
 
 def run_auto_knockout():
@@ -206,5 +417,37 @@ def run_auto_knockout():
             challenge_week.challenge_week_id,
         )
         return apply_auto_knockout_for_week(cur, challenge_week, participants)
+
+    return with_psycopg(fn)
+
+
+def run_auto_knockout_alerts():
+    from helpers import with_psycopg
+
+    def fn(conn, cur):
+        challenge_week = get_current_challenge_week(cur)
+        if challenge_week is None:
+            logging.info("Auto-knockout alerts skipped: no current challenge week")
+            return []
+
+        if challenge_week.bye_week:
+            logging.info(
+                "Auto-knockout alerts skipped: challenge week %s is a bye week",
+                challenge_week.challenge_week_id,
+            )
+            return []
+
+        run_date = datetime.now(tz=ZoneInfo("America/New_York")).date()
+        participants = get_alert_participants_for_week(
+            cur,
+            challenge_week.challenge_id,
+            challenge_week.challenge_week_id,
+            run_date.strftime("%A"),
+        )
+        return build_auto_knockout_alerts_for_week(
+            challenge_week,
+            run_date,
+            participants,
+        )
 
     return with_psycopg(fn)

--- a/src/auto_knockout.py
+++ b/src/auto_knockout.py
@@ -104,7 +104,9 @@ def get_previous_challenge_week(cur):
             cw.bye_week
         from challenge_weeks cw
         join challenges c on c.id = cw.challenge_id
-        where cw."end" < (current_timestamp at time zone 'America/New_York')::date
+        where cw."end" = (
+            (current_timestamp at time zone 'America/New_York')::date - interval '1 day'
+        )::date
         order by cw."end" desc
         limit 1;
         """
@@ -145,6 +147,7 @@ def get_participants_for_week(cur, challenge_id, challenge_week_id):
             ch.discord_id,
             ch.tz,
             cc.mulligan,
+            mulligan_checkin.challenge_week_id as mulligan_challenge_week_id,
             count(distinct c.day_of_week) filter (
                 where c.tier != 'T0'
             ) as checkin_count,
@@ -156,6 +159,7 @@ def get_participants_for_week(cur, challenge_id, challenge_week_id):
             ) as checked_in_days
         from challenger_challenges cc
         join challengers ch on ch.id = cc.challenger_id
+        left join checkins mulligan_checkin on mulligan_checkin.id = cc.mulligan
         left join checkins c on
             c.challenger = ch.id
             and c.challenge_week_id = %s
@@ -163,7 +167,13 @@ def get_participants_for_week(cur, challenge_id, challenge_week_id):
             cc.challenge_id = %s
             and cc.knocked_out = false
             and coalesce(cc.tier, '') != 'T0'
-        group by ch.id, ch.name, ch.discord_id, ch.tz, cc.mulligan
+        group by
+            ch.id,
+            ch.name,
+            ch.discord_id,
+            ch.tz,
+            cc.mulligan,
+            mulligan_checkin.challenge_week_id
         order by ch.name;
         """,
         (challenge_week_id, challenge_id),
@@ -267,6 +277,13 @@ def apply_auto_knockout_for_week(cur, challenge_week, participants):
     for participant in participants:
         checkin_count = participant.checkin_count or 0
         if checkin_count >= required_checkins:
+            continue
+
+        if (
+            participant.mulligan is not None
+            and getattr(participant, "mulligan_challenge_week_id", None)
+            == challenge_week.challenge_week_id
+        ):
             continue
 
         if participant.mulligan is None:
@@ -409,6 +426,13 @@ def run_auto_knockout():
         challenge_week = get_previous_challenge_week(cur)
         if challenge_week is None:
             logging.info("Auto-knockout skipped: no completed challenge week")
+            return []
+
+        if challenge_week.bye_week:
+            logging.info(
+                "Auto-knockout skipped: challenge week %s is a bye week",
+                challenge_week.challenge_week_id,
+            )
             return []
 
         participants = get_participants_for_week(

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -1,7 +1,12 @@
 from rq import cron
 from helpers import fetchall
 from green import determine_if_green
-from auto_knockout import run_auto_knockout
+from auto_knockout import (
+    build_auto_knockout_alert_message,
+    build_auto_knockout_reconciliation_message,
+    run_auto_knockout,
+    run_auto_knockout_alerts,
+)
 import discord
 from discord_bot import bot
 import os
@@ -122,10 +127,35 @@ cron.register(challenge_start_message, queue_name="cron", cron="0 14 * * 1")
 async def auto_knockout():
     logging.info("Running auto-knockout")
     events = run_auto_knockout()
+    message = build_auto_knockout_reconciliation_message(events)
+    if message is not None:
+        channel = await get_channel()
+        if channel is None:
+            logging.warning("Cannot send auto-knockout message: channel not found")
+        else:
+            await channel.send(message)
     logging.info("Auto-knockout completed with %s state changes", len(events))
 
 
 cron.register(auto_knockout, queue_name="cron", cron="5 14 * * 1")
+
+
+async def auto_knockout_alerts():
+    logging.info("Running auto-knockout alerts")
+    events = run_auto_knockout_alerts()
+    message = build_auto_knockout_alert_message(events)
+    if message is None:
+        logging.info("Auto-knockout alerts completed with no warnings")
+        return
+
+    channel = await get_channel()
+    if channel is None:
+        logging.warning("Cannot send auto-knockout alert message: channel not found")
+        return
+    await channel.send(message)
+
+
+cron.register(auto_knockout_alerts, queue_name="cron", cron="10 14 * * *")
 
 # def check_mulligans():
 #    logging.info("checking for mulligans")

--- a/tests/test_auto_knockout.py
+++ b/tests/test_auto_knockout.py
@@ -4,6 +4,7 @@ import unittest
 from datetime import date
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import patch
 
 
 os.environ.setdefault("DB_CONNECT_STRING", "postgresql://postgres:password@localhost/projects")
@@ -19,18 +20,20 @@ from auto_knockout import (
     first_missed_day,
     get_alert_participants_for_week,
     get_participants_for_week,
+    get_previous_challenge_week,
+    run_auto_knockout,
     should_send_first_no_slack_warning,
 )
 
 
-def challenge_week(green=False):
+def challenge_week(green=False, bye_week=False):
     return SimpleNamespace(
         challenge_id=1,
         challenge_week_id=10,
         start=date(2026, 4, 27),
         end=date(2026, 5, 3),
         green=green,
-        bye_week=False,
+        bye_week=bye_week,
     )
 
 
@@ -42,6 +45,7 @@ def participant(
     challenger_id=1,
     name="Test User",
     current_day_checked_in=False,
+    mulligan_challenge_week_id=None,
 ):
     return SimpleNamespace(
         id=challenger_id,
@@ -52,6 +56,7 @@ def participant(
         checkin_count=checkin_count,
         checked_in_days=checked_in_days or [],
         current_day_checked_in=current_day_checked_in,
+        mulligan_challenge_week_id=mulligan_challenge_week_id,
     )
 
 
@@ -68,6 +73,21 @@ class FakeCursor:
 
     def fetchall(self):
         return []
+
+
+class FakeRunCursor:
+    def __init__(self, challenge_week_result):
+        self.queries = []
+        self.challenge_week_result = challenge_week_result
+
+    def execute(self, sql, params=None):
+        self.queries.append((sql, params))
+
+    def fetchone(self):
+        return self.challenge_week_result
+
+    def fetchall(self):
+        raise AssertionError("participants should not be fetched")
 
 
 def query_texts(cur):
@@ -118,6 +138,45 @@ class AutoKnockoutTests(unittest.TestCase):
         self.assertEqual(events[0].discord_id, "1001")
         self.assertIn("set knocked_out = true", query_texts(cur)[0])
 
+    def test_rerun_skips_challenger_with_mulligan_from_same_week(self):
+        cur = FakeCursor()
+
+        events = apply_auto_knockout_for_week(
+            cur,
+            challenge_week(),
+            [
+                participant(
+                    checkin_count=1,
+                    checked_in_days=["Monday"],
+                    mulligan=123,
+                    mulligan_challenge_week_id=10,
+                )
+            ],
+        )
+
+        self.assertEqual(events, [])
+        self.assertEqual(cur.queries, [])
+
+    def test_prior_week_mulligan_still_allows_knockout(self):
+        cur = FakeCursor()
+
+        events = apply_auto_knockout_for_week(
+            cur,
+            challenge_week(),
+            [
+                participant(
+                    checkin_count=1,
+                    checked_in_days=["Monday"],
+                    mulligan=123,
+                    mulligan_challenge_week_id=9,
+                )
+            ],
+        )
+
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].action, "knockout")
+        self.assertIn("set knocked_out = true", query_texts(cur)[0])
+
     def test_zero_checkin_challenger_gets_mulligan_on_first_day(self):
         cur = FakeCursor()
 
@@ -164,6 +223,42 @@ class AutoKnockoutTests(unittest.TestCase):
 
         self.assertIn("ch.discord_id", query_texts(cur)[0])
         self.assertIn("cc.knocked_out = false", query_texts(cur)[0])
+
+    def test_participant_query_exposes_mulligan_challenge_week(self):
+        cur = FakeCursor()
+
+        get_participants_for_week(cur, challenge_id=1, challenge_week_id=10)
+
+        self.assertIn(
+            "mulligan_checkin.challenge_week_id as mulligan_challenge_week_id",
+            query_texts(cur)[0],
+        )
+        self.assertIn("left join checkins mulligan_checkin", query_texts(cur)[0])
+
+    def test_previous_challenge_week_only_targets_week_ending_yesterday(self):
+        cur = FakeCursor()
+
+        get_previous_challenge_week(cur)
+
+        self.assertIn('cw."end" = (', query_texts(cur)[0])
+        self.assertIn("interval '1 day'", query_texts(cur)[0])
+
+    def test_auto_knockout_skips_bye_week(self):
+        captured = {}
+
+        def fake_with_psycopg(fn):
+            cur = FakeRunCursor(challenge_week(bye_week=True))
+            captured["cur"] = cur
+            return fn(None, cur)
+
+        with patch.dict(
+            sys.modules,
+            {"helpers": SimpleNamespace(with_psycopg=fake_with_psycopg)},
+        ):
+            events = run_auto_knockout()
+
+        self.assertEqual(events, [])
+        self.assertEqual(len(captured["cur"].queries), 1)
 
     def test_normal_week_alert_when_no_mulligan_challenger_has_no_slack(self):
         events = build_auto_knockout_alerts_for_week(

--- a/tests/test_auto_knockout.py
+++ b/tests/test_auto_knockout.py
@@ -11,9 +11,15 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT / "src"))
 
 from auto_knockout import (
+    AutoKnockoutEvent,
     apply_auto_knockout_for_week,
+    build_auto_knockout_alert_message,
+    build_auto_knockout_alerts_for_week,
+    build_auto_knockout_reconciliation_message,
     first_missed_day,
+    get_alert_participants_for_week,
     get_participants_for_week,
+    should_send_first_no_slack_warning,
 )
 
 
@@ -22,7 +28,9 @@ def challenge_week(green=False):
         challenge_id=1,
         challenge_week_id=10,
         start=date(2026, 4, 27),
+        end=date(2026, 5, 3),
         green=green,
+        bye_week=False,
     )
 
 
@@ -33,14 +41,17 @@ def participant(
     mulligan=None,
     challenger_id=1,
     name="Test User",
+    current_day_checked_in=False,
 ):
     return SimpleNamespace(
         id=challenger_id,
         name=name,
+        discord_id=str(1000 + challenger_id),
         tz="America/New_York",
         mulligan=mulligan,
         checkin_count=checkin_count,
         checked_in_days=checked_in_days or [],
+        current_day_checked_in=current_day_checked_in,
     )
 
 
@@ -89,6 +100,7 @@ class AutoKnockoutTests(unittest.TestCase):
         self.assertEqual(events[0].action, "mulligan")
         self.assertEqual(events[0].mulligan_checkin_id, 123)
         self.assertEqual(events[0].mulligan_day, "Tuesday")
+        self.assertEqual(events[0].discord_id, "1001")
         self.assertIn("insert into checkins", query_texts(cur)[0])
         self.assertIn("set mulligan", query_texts(cur)[1])
 
@@ -103,6 +115,7 @@ class AutoKnockoutTests(unittest.TestCase):
 
         self.assertEqual(len(events), 1)
         self.assertEqual(events[0].action, "knockout")
+        self.assertEqual(events[0].discord_id, "1001")
         self.assertIn("set knocked_out = true", query_texts(cur)[0])
 
     def test_zero_checkin_challenger_gets_mulligan_on_first_day(self):
@@ -149,7 +162,168 @@ class AutoKnockoutTests(unittest.TestCase):
 
         get_participants_for_week(cur, challenge_id=1, challenge_week_id=10)
 
+        self.assertIn("ch.discord_id", query_texts(cur)[0])
         self.assertIn("cc.knocked_out = false", query_texts(cur)[0])
+
+    def test_normal_week_alert_when_no_mulligan_challenger_has_no_slack(self):
+        events = build_auto_knockout_alerts_for_week(
+            challenge_week(),
+            date(2026, 5, 2),
+            [participant(checkin_count=0, mulligan=99)],
+        )
+
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].action, "warning")
+        self.assertEqual(events[0].remaining_checkin_days, ("Saturday", "Sunday"))
+        self.assertFalse(events[0].has_mulligan_available)
+
+    def test_green_week_alert_uses_five_checkin_requirement(self):
+        events = build_auto_knockout_alerts_for_week(
+            challenge_week(green=True),
+            date(2026, 5, 2),
+            [
+                participant(
+                    checkin_count=3,
+                    checked_in_days=["Monday", "Tuesday", "Wednesday"],
+                    mulligan=99,
+                )
+            ],
+        )
+
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].required_checkins, 5)
+        self.assertEqual(events[0].remaining_checkin_days, ("Saturday", "Sunday"))
+
+    def test_alert_skipped_when_challenger_still_has_slack(self):
+        events = build_auto_knockout_alerts_for_week(
+            challenge_week(green=True),
+            date(2026, 4, 29),
+            [participant(checkin_count=1, checked_in_days=["Monday"])],
+        )
+
+        self.assertEqual(events, [])
+
+    def test_alert_skipped_after_user_responds_to_first_warning(self):
+        events = build_auto_knockout_alerts_for_week(
+            challenge_week(green=True),
+            date(2026, 4, 30),
+            [participant(checkin_count=1, checked_in_days=["Wednesday"], mulligan=99)],
+        )
+
+        self.assertEqual(events, [])
+
+    def test_normal_week_alert_skipped_after_user_responds_to_first_warning(self):
+        events = build_auto_knockout_alerts_for_week(
+            challenge_week(),
+            date(2026, 5, 3),
+            [participant(checkin_count=1, checked_in_days=["Saturday"], mulligan=99)],
+        )
+
+        self.assertEqual(events, [])
+
+    def test_first_no_slack_warning_requires_latest_miss_to_create_no_slack(self):
+        week = challenge_week(green=True)
+
+        self.assertTrue(
+            should_send_first_no_slack_warning(
+                week,
+                date(2026, 4, 29),
+                required_checkins=5,
+                checked_in_days=[],
+            )
+        )
+        self.assertFalse(
+            should_send_first_no_slack_warning(
+                week,
+                date(2026, 4, 30),
+                required_checkins=5,
+                checked_in_days=["Wednesday"],
+            )
+        )
+
+    def test_alert_query_skips_knocked_out_and_t0_challengers(self):
+        cur = FakeCursor()
+
+        get_alert_participants_for_week(
+            cur,
+            challenge_id=1,
+            challenge_week_id=10,
+            run_day="Saturday",
+        )
+
+        self.assertIn("cc.knocked_out = false", query_texts(cur)[0])
+        self.assertIn("coalesce(cc.tier, '') != 'T0'", query_texts(cur)[0])
+        self.assertIn("checked_in_days", query_texts(cur)[0])
+
+    def test_alert_message_mentions_discord_ids_and_remaining_days(self):
+        events = build_auto_knockout_alerts_for_week(
+            challenge_week(),
+            date(2026, 5, 2),
+            [participant(checkin_count=0, mulligan=99)],
+        )
+
+        message = build_auto_knockout_alert_message(events)
+
+        self.assertIn("<@1001>", message)
+        self.assertIn("Saturday and Sunday", message)
+        self.assertIn("to avoid knockout", message)
+
+    def test_alert_message_mentions_mulligan_risk_when_mulligan_available(self):
+        events = build_auto_knockout_alerts_for_week(
+            challenge_week(),
+            date(2026, 5, 2),
+            [participant(checkin_count=0, mulligan=None)],
+        )
+
+        message = build_auto_knockout_alert_message(events)
+
+        self.assertIn("to avoid using a mulligan or being knocked out", message)
+
+    def test_reconciliation_message_mentions_mulligan_used(self):
+        message = build_auto_knockout_reconciliation_message(
+            [
+                AutoKnockoutEvent(
+                    action="mulligan",
+                    challenge_id=1,
+                    challenger_id=1,
+                    name="Test User",
+                    required_checkins=2,
+                    checkin_count=1,
+                    challenge_week_id=10,
+                    discord_id="123",
+                    mulligan_checkin_id=456,
+                    mulligan_day="Tuesday",
+                )
+            ]
+        )
+
+        self.assertIn("## Mulligans used", message)
+        self.assertIn(
+            "<@123> was saved from knockout by their mulligan on Tuesday.",
+            message,
+        )
+
+    def test_reconciliation_message_mentions_knockout(self):
+        message = build_auto_knockout_reconciliation_message(
+            [
+                AutoKnockoutEvent(
+                    action="knockout",
+                    challenge_id=1,
+                    challenger_id=1,
+                    name="Test User",
+                    required_checkins=5,
+                    checkin_count=3,
+                    challenge_week_id=10,
+                    discord_id="123",
+                )
+            ]
+        )
+
+        self.assertIn("## Knockouts", message)
+        self.assertIn(
+            "<@123> has been knocked out with 3/5 T1+ check-ins this week.",
+            message,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Adds Discord reconciliation messages for the weekly auto-knockout job so mulligan saves and knockouts are announced after the job runs.
- Adds daily Discord warning alerts for challengers who have just run out of slack, including whether the risk is using a mulligan or being knocked out.
- Hardens reconciliation after PR #51 by processing only the challenge week that ended yesterday, skipping bye weeks, and avoiding a same-week rerun turning a newly inserted mulligan into a knockout.

## Major Changes
- `src/auto_knockout.py`: extends auto-knockout events with Discord metadata, adds current-week alert queries, builds warning/reconciliation message text, adds no-slack warning rules, and tracks the week tied to an existing mulligan for idempotent reruns.
- `src/tasks.py`: posts weekly reconciliation results to Discord and schedules a daily warning task for the current challenge week.
- `tests/test_auto_knockout.py`: adds coverage for alert timing, generated Discord copy, bye-week skips, yesterday-only reconciliation, same-week mulligan reruns, prior-week mulligan knockouts, and the new participant SQL fields.

## Test Plan
- `python3 -m unittest tests/test_auto_knockout.py`

Made with [Cursor](https://cursor.com)