### PR TITLE
Improve knockout warning clarity

### DIFF
--- a/src/auto_knockout.py
+++ b/src/auto_knockout.py
@@ -85,15 +85,19 @@ def mulligan_used_on_latest_elapsed_day(challenge_week, run_date, participant):
     return getattr(participant, "mulligan_day", None) == latest_elapsed_day
 
 
-def format_day_list(days):
-    days = list(days)
-    if len(days) == 0:
+def format_natural_language_list(items):
+    items = list(items)
+    if len(items) == 0:
         return ""
-    if len(days) == 1:
-        return days[0]
-    if len(days) == 2:
-        return f"{days[0]} and {days[1]}"
-    return f"{', '.join(days[:-1])}, and {days[-1]}"
+    if len(items) == 1:
+        return items[0]
+    if len(items) == 2:
+        return f"{items[0]} and {items[1]}"
+    return f"{', '.join(items[:-1])}, and {items[-1]}"
+
+
+def format_day_list(days):
+    return format_natural_language_list(days)
 
 
 def first_missed_day(week_start, checked_in_days):
@@ -411,17 +415,24 @@ def build_auto_knockout_alert_message(events):
     if len(warnings) == 0:
         return None
 
-    lines = []
+    groups = {}
     for event in warnings:
-        days = format_day_list(event.remaining_checkin_days)
+        key = (event.remaining_checkin_days, event.has_mulligan_available)
+        groups.setdefault(key, []).append(event)
+
+    lines = []
+    for (remaining_checkin_days, has_mulligan_available), group in groups.items():
+        mentions = format_natural_language_list(
+            f"<@{event.discord_id}>" for event in group
+        )
+        days = format_day_list(remaining_checkin_days)
+        emoji = "⚠️" if has_mulligan_available else "🚨"
         consequence = (
             "to avoid using a mulligan"
-            if event.has_mulligan_available
+            if has_mulligan_available
             else "to avoid being knocked out"
         )
-        lines.append(
-            f"<@{event.discord_id}> must check in on {days} {consequence}."
-        )
+        lines.append(f"{emoji} {mentions} must check in on {days} {consequence}.")
 
     return "## Knockout warnings\n" + "\n".join(lines)
 

--- a/src/auto_knockout.py
+++ b/src/auto_knockout.py
@@ -67,6 +67,24 @@ def should_send_first_no_slack_warning(challenge_week, run_date, required_checki
     return len(missed_prior_days) > 0 and missed_prior_days[-1] == prior_days[-1]
 
 
+def mulligan_used_on_latest_elapsed_day(challenge_week, run_date, participant):
+    if (
+        participant.mulligan is None
+        or getattr(participant, "mulligan_challenge_week_id", None)
+        != challenge_week.challenge_week_id
+    ):
+        return False
+
+    days_elapsed = min(max((run_date - challenge_week.start).days, 0), 7)
+    if days_elapsed == 0:
+        return False
+
+    latest_elapsed_day = (
+        challenge_week.start + timedelta(days=days_elapsed - 1)
+    ).strftime("%A")
+    return getattr(participant, "mulligan_day", None) == latest_elapsed_day
+
+
 def format_day_list(days):
     days = list(days)
     if len(days) == 0:
@@ -190,6 +208,8 @@ def get_alert_participants_for_week(cur, challenge_id, challenge_week_id, run_da
             ch.discord_id,
             ch.tz,
             cc.mulligan,
+            mulligan_checkin.challenge_week_id as mulligan_challenge_week_id,
+            mulligan_checkin.day_of_week as mulligan_day,
             count(distinct c.day_of_week) filter (
                 where c.tier != 'T0'
             ) as checkin_count,
@@ -205,6 +225,7 @@ def get_alert_participants_for_week(cur, challenge_id, challenge_week_id, run_da
             ) as current_day_checked_in
         from challenger_challenges cc
         join challengers ch on ch.id = cc.challenger_id
+        left join checkins mulligan_checkin on mulligan_checkin.id = cc.mulligan
         left join checkins c on
             c.challenger = ch.id
             and c.challenge_week_id = %s
@@ -212,7 +233,14 @@ def get_alert_participants_for_week(cur, challenge_id, challenge_week_id, run_da
             cc.challenge_id = %s
             and cc.knocked_out = false
             and coalesce(cc.tier, '') != 'T0'
-        group by ch.id, ch.name, ch.discord_id, ch.tz, cc.mulligan
+        group by
+            ch.id,
+            ch.name,
+            ch.discord_id,
+            ch.tz,
+            cc.mulligan,
+            mulligan_checkin.challenge_week_id,
+            mulligan_checkin.day_of_week
         order by ch.name;
         """,
         (run_day, challenge_week_id, challenge_id),
@@ -346,12 +374,18 @@ def build_auto_knockout_alerts_for_week(challenge_week, run_date, participants):
         if needed_checkins < len(effective_remaining_days):
             continue
 
-        if not should_send_first_no_slack_warning(
+        is_first_no_slack_warning = should_send_first_no_slack_warning(
             challenge_week,
             run_date,
             required_checkins,
             participant.checked_in_days,
-        ):
+        )
+        consequence_changed_after_mulligan = mulligan_used_on_latest_elapsed_day(
+            challenge_week,
+            run_date,
+            participant,
+        )
+        if not is_first_no_slack_warning and not consequence_changed_after_mulligan:
             continue
 
         events.append(
@@ -381,9 +415,9 @@ def build_auto_knockout_alert_message(events):
     for event in warnings:
         days = format_day_list(event.remaining_checkin_days)
         consequence = (
-            "to avoid using a mulligan or being knocked out"
+            "to avoid using a mulligan"
             if event.has_mulligan_available
-            else "to avoid knockout"
+            else "to avoid being knocked out"
         )
         lines.append(
             f"<@{event.discord_id}> must check in on {days} {consequence}."

--- a/src/auto_knockout.py
+++ b/src/auto_knockout.py
@@ -461,7 +461,7 @@ def build_auto_knockout_reconciliation_message(events):
     if len(sections) == 0:
         return None
 
-    return "\n\n".join(sections)
+    return "\n".join(sections)
 
 
 def run_auto_knockout():

--- a/tests/test_auto_knockout.py
+++ b/tests/test_auto_knockout.py
@@ -46,6 +46,7 @@ def participant(
     name="Test User",
     current_day_checked_in=False,
     mulligan_challenge_week_id=None,
+    mulligan_day=None,
 ):
     return SimpleNamespace(
         id=challenger_id,
@@ -57,6 +58,7 @@ def participant(
         checked_in_days=checked_in_days or [],
         current_day_checked_in=current_day_checked_in,
         mulligan_challenge_week_id=mulligan_challenge_week_id,
+        mulligan_day=mulligan_day,
     )
 
 
@@ -316,6 +318,42 @@ class AutoKnockoutTests(unittest.TestCase):
 
         self.assertEqual(events, [])
 
+    def test_sunday_alert_after_saturday_mulligan_warns_of_knockout(self):
+        saturday_events = build_auto_knockout_alerts_for_week(
+            challenge_week(),
+            date(2026, 5, 2),
+            [participant(checkin_count=0, mulligan=None)],
+        )
+
+        self.assertEqual(len(saturday_events), 1)
+        self.assertTrue(saturday_events[0].has_mulligan_available)
+        self.assertIn(
+            "to avoid using a mulligan",
+            build_auto_knockout_alert_message(saturday_events),
+        )
+
+        sunday_events = build_auto_knockout_alerts_for_week(
+            challenge_week(),
+            date(2026, 5, 3),
+            [
+                participant(
+                    checkin_count=1,
+                    checked_in_days=["Saturday"],
+                    mulligan=99,
+                    mulligan_challenge_week_id=10,
+                    mulligan_day="Saturday",
+                )
+            ],
+        )
+
+        self.assertEqual(len(sunday_events), 1)
+        self.assertFalse(sunday_events[0].has_mulligan_available)
+        self.assertEqual(sunday_events[0].remaining_checkin_days, ("Sunday",))
+        self.assertIn(
+            "to avoid being knocked out",
+            build_auto_knockout_alert_message(sunday_events),
+        )
+
     def test_first_no_slack_warning_requires_latest_miss_to_create_no_slack(self):
         week = challenge_week(green=True)
 
@@ -349,6 +387,15 @@ class AutoKnockoutTests(unittest.TestCase):
         self.assertIn("cc.knocked_out = false", query_texts(cur)[0])
         self.assertIn("coalesce(cc.tier, '') != 'T0'", query_texts(cur)[0])
         self.assertIn("checked_in_days", query_texts(cur)[0])
+        self.assertIn(
+            "mulligan_checkin.challenge_week_id as mulligan_challenge_week_id",
+            query_texts(cur)[0],
+        )
+        self.assertIn(
+            "mulligan_checkin.day_of_week as mulligan_day",
+            query_texts(cur)[0],
+        )
+        self.assertIn("left join checkins mulligan_checkin", query_texts(cur)[0])
 
     def test_alert_message_mentions_discord_ids_and_remaining_days(self):
         events = build_auto_knockout_alerts_for_week(
@@ -361,7 +408,8 @@ class AutoKnockoutTests(unittest.TestCase):
 
         self.assertIn("<@1001>", message)
         self.assertIn("Saturday and Sunday", message)
-        self.assertIn("to avoid knockout", message)
+        self.assertIn("to avoid being knocked out", message)
+        self.assertNotIn("mulligan", message)
 
     def test_alert_message_mentions_mulligan_risk_when_mulligan_available(self):
         events = build_auto_knockout_alerts_for_week(
@@ -372,7 +420,31 @@ class AutoKnockoutTests(unittest.TestCase):
 
         message = build_auto_knockout_alert_message(events)
 
-        self.assertIn("to avoid using a mulligan or being knocked out", message)
+        self.assertIn("to avoid using a mulligan", message)
+        self.assertNotIn("being knocked out", message)
+
+    def test_alert_message_uses_distinct_consequences_per_user(self):
+        events = build_auto_knockout_alerts_for_week(
+            challenge_week(),
+            date(2026, 5, 2),
+            [
+                participant(checkin_count=0, mulligan=None),
+                participant(checkin_count=0, mulligan=99, challenger_id=2),
+            ],
+        )
+
+        message = build_auto_knockout_alert_message(events)
+
+        self.assertIn(
+            "<@1001> must check in on Saturday and Sunday "
+            "to avoid using a mulligan.",
+            message,
+        )
+        self.assertIn(
+            "<@1002> must check in on Saturday and Sunday "
+            "to avoid being knocked out.",
+            message,
+        )
 
     def test_reconciliation_message_mentions_mulligan_used(self):
         message = build_auto_knockout_reconciliation_message(

--- a/tests/test_auto_knockout.py
+++ b/tests/test_auto_knockout.py
@@ -406,10 +406,14 @@ class AutoKnockoutTests(unittest.TestCase):
 
         message = build_auto_knockout_alert_message(events)
 
-        self.assertIn("<@1001>", message)
-        self.assertIn("Saturday and Sunday", message)
-        self.assertIn("to avoid being knocked out", message)
+        self.assertEqual(
+            message,
+            "## Knockout warnings\n"
+            "🚨 <@1001> must check in on Saturday and Sunday "
+            "to avoid being knocked out.",
+        )
         self.assertNotIn("mulligan", message)
+        self.assertFalse(message.endswith("\n"))
 
     def test_alert_message_mentions_mulligan_risk_when_mulligan_available(self):
         events = build_auto_knockout_alerts_for_week(
@@ -420,31 +424,67 @@ class AutoKnockoutTests(unittest.TestCase):
 
         message = build_auto_knockout_alert_message(events)
 
-        self.assertIn("to avoid using a mulligan", message)
+        self.assertEqual(
+            message,
+            "## Knockout warnings\n"
+            "⚠️ <@1001> must check in on Saturday and Sunday "
+            "to avoid using a mulligan.",
+        )
         self.assertNotIn("being knocked out", message)
+        self.assertFalse(message.endswith("\n"))
 
-    def test_alert_message_uses_distinct_consequences_per_user(self):
+    def test_alert_message_groups_users_with_identical_conditions(self):
         events = build_auto_knockout_alerts_for_week(
             challenge_week(),
             date(2026, 5, 2),
             [
                 participant(checkin_count=0, mulligan=None),
-                participant(checkin_count=0, mulligan=99, challenger_id=2),
+                participant(checkin_count=0, mulligan=None, challenger_id=2),
+                participant(checkin_count=0, mulligan=None, challenger_id=3),
+                participant(checkin_count=0, mulligan=99, challenger_id=4),
+                participant(checkin_count=0, mulligan=99, challenger_id=5),
             ],
         )
 
         message = build_auto_knockout_alert_message(events)
 
-        self.assertIn(
-            "<@1001> must check in on Saturday and Sunday "
-            "to avoid using a mulligan.",
+        self.assertEqual(
             message,
-        )
-        self.assertIn(
-            "<@1002> must check in on Saturday and Sunday "
+            "## Knockout warnings\n"
+            "⚠️ <@1001>, <@1002>, and <@1003> must check in on "
+            "Saturday and Sunday to avoid using a mulligan.\n"
+            "🚨 <@1004> and <@1005> must check in on Saturday and Sunday "
             "to avoid being knocked out.",
-            message,
         )
+        self.assertEqual(message.count("\n"), 2)
+        self.assertFalse(message.endswith("\n"))
+
+    def test_alert_message_keeps_different_checkin_days_separate(self):
+        events = build_auto_knockout_alerts_for_week(
+            challenge_week(),
+            date(2026, 5, 2),
+            [
+                participant(checkin_count=0, mulligan=None),
+                participant(
+                    checkin_count=1,
+                    checked_in_days=["Saturday"],
+                    current_day_checked_in=True,
+                    mulligan=None,
+                    challenger_id=2,
+                ),
+            ],
+        )
+
+        message = build_auto_knockout_alert_message(events)
+
+        self.assertEqual(
+            message,
+            "## Knockout warnings\n"
+            "⚠️ <@1001> must check in on Saturday and Sunday "
+            "to avoid using a mulligan.\n"
+            "⚠️ <@1002> must check in on Sunday to avoid using a mulligan.",
+        )
+        self.assertFalse(message.endswith("\n"))
 
     def test_reconciliation_message_mentions_mulligan_used(self):
         message = build_auto_knockout_reconciliation_message(

--- a/tests/test_auto_knockout.py
+++ b/tests/test_auto_knockout.py
@@ -457,6 +457,7 @@ class AutoKnockoutTests(unittest.TestCase):
             "to avoid being knocked out.",
         )
         self.assertEqual(message.count("\n"), 2)
+        self.assertNotIn("\n\n", message)
         self.assertFalse(message.endswith("\n"))
 
     def test_alert_message_keeps_different_checkin_days_separate(self):
@@ -504,11 +505,12 @@ class AutoKnockoutTests(unittest.TestCase):
             ]
         )
 
-        self.assertIn("## Mulligans used", message)
-        self.assertIn(
-            "<@123> was saved from knockout by their mulligan on Tuesday.",
+        self.assertEqual(
             message,
+            "## Mulligans used\n"
+            "<@123> was saved from knockout by their mulligan on Tuesday.",
         )
+        self.assertFalse(message.endswith("\n"))
 
     def test_reconciliation_message_mentions_knockout(self):
         message = build_auto_knockout_reconciliation_message(
@@ -526,11 +528,50 @@ class AutoKnockoutTests(unittest.TestCase):
             ]
         )
 
-        self.assertIn("## Knockouts", message)
-        self.assertIn(
-            "<@123> has been knocked out with 3/5 T1+ check-ins this week.",
+        self.assertEqual(
             message,
+            "## Knockouts\n"
+            "<@123> has been knocked out with 3/5 T1+ check-ins this week.",
         )
+        self.assertFalse(message.endswith("\n"))
+
+    def test_reconciliation_message_uses_one_line_break_between_sections(self):
+        message = build_auto_knockout_reconciliation_message(
+            [
+                AutoKnockoutEvent(
+                    action="mulligan",
+                    challenge_id=1,
+                    challenger_id=1,
+                    name="Mulligan User",
+                    required_checkins=2,
+                    checkin_count=1,
+                    challenge_week_id=10,
+                    discord_id="123",
+                    mulligan_checkin_id=456,
+                    mulligan_day="Tuesday",
+                ),
+                AutoKnockoutEvent(
+                    action="knockout",
+                    challenge_id=1,
+                    challenger_id=2,
+                    name="Knocked Out User",
+                    required_checkins=2,
+                    checkin_count=1,
+                    challenge_week_id=10,
+                    discord_id="456",
+                ),
+            ]
+        )
+
+        self.assertEqual(
+            message,
+            "## Mulligans used\n"
+            "<@123> was saved from knockout by their mulligan on Tuesday.\n"
+            "## Knockouts\n"
+            "<@456> has been knocked out with 1/2 T1+ check-ins this week.",
+        )
+        self.assertNotIn("\n\n", message)
+        self.assertFalse(message.endswith("\n"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- update warning consequences after mulligans so alerts match final enforcement
- group participants with identical warning conditions and add severity indicators
- tighten Discord message spacing and exact-output coverage

## Test plan
- [x] `python3 -m unittest tests.test_auto_knockout`
- [x] `python -m unittest discover -s tests` in the application Docker image


Made with [Cursor](https://cursor.com)