### PR TITLE
Revert mulligan weekly requirement change

### DIFF
--- a/src/auto_knockout.py
+++ b/src/auto_knockout.py
@@ -279,8 +279,14 @@ def apply_auto_knockout_for_week(cur, challenge_week, participants):
         if checkin_count >= required_checkins:
             continue
 
-        checkin_shortfall = required_checkins - checkin_count
-        if participant.mulligan is None and checkin_shortfall == 1:
+        if (
+            participant.mulligan is not None
+            and getattr(participant, "mulligan_challenge_week_id", None)
+            == challenge_week.challenge_week_id
+        ):
+            continue
+
+        if participant.mulligan is None:
             mulligan_id, mulligan_day = insert_mulligan(cur, participant, challenge_week)
             events.append(
                 AutoKnockoutEvent(
@@ -296,21 +302,20 @@ def apply_auto_knockout_for_week(cur, challenge_week, participants):
                     mulligan_day=mulligan_day,
                 )
             )
-            continue
-
-        knock_out_challenger(cur, participant, challenge_week)
-        events.append(
-            AutoKnockoutEvent(
-                action="knockout",
-                challenge_id=challenge_week.challenge_id,
-                challenger_id=participant.id,
-                name=participant.name,
-                required_checkins=required_checkins,
-                checkin_count=checkin_count,
-                challenge_week_id=challenge_week.challenge_week_id,
-                discord_id=participant.discord_id,
+        else:
+            knock_out_challenger(cur, participant, challenge_week)
+            events.append(
+                AutoKnockoutEvent(
+                    action="knockout",
+                    challenge_id=challenge_week.challenge_id,
+                    challenger_id=participant.id,
+                    name=participant.name,
+                    required_checkins=required_checkins,
+                    checkin_count=checkin_count,
+                    challenge_week_id=challenge_week.challenge_week_id,
+                    discord_id=participant.discord_id,
+                )
             )
-        )
 
     return events
 

--- a/tests/test_auto_knockout.py
+++ b/tests/test_auto_knockout.py
@@ -123,7 +123,6 @@ class AutoKnockoutTests(unittest.TestCase):
         self.assertEqual(events[0].discord_id, "1001")
         self.assertIn("insert into checkins", query_texts(cur)[0])
         self.assertIn("set mulligan", query_texts(cur)[1])
-        self.assertNotIn("set knocked_out = true", " ".join(query_texts(cur)))
 
     def test_knockout_set_when_below_requirement_with_existing_mulligan(self):
         cur = FakeCursor()
@@ -139,7 +138,7 @@ class AutoKnockoutTests(unittest.TestCase):
         self.assertEqual(events[0].discord_id, "1001")
         self.assertIn("set knocked_out = true", query_texts(cur)[0])
 
-    def test_saturday_mulligan_does_not_prevent_knockout_after_sunday_miss(self):
+    def test_rerun_skips_challenger_with_mulligan_from_same_week(self):
         cur = FakeCursor()
 
         events = apply_auto_knockout_for_week(
@@ -148,17 +147,15 @@ class AutoKnockoutTests(unittest.TestCase):
             [
                 participant(
                     checkin_count=1,
-                    checked_in_days=["Saturday"],
+                    checked_in_days=["Monday"],
                     mulligan=123,
                     mulligan_challenge_week_id=10,
                 )
             ],
         )
 
-        self.assertEqual(len(events), 1)
-        self.assertEqual(events[0].action, "knockout")
-        self.assertEqual(events[0].checkin_count, 1)
-        self.assertIn("set knocked_out = true", query_texts(cur)[0])
+        self.assertEqual(events, [])
+        self.assertEqual(cur.queries, [])
 
     def test_prior_week_mulligan_still_allows_knockout(self):
         cur = FakeCursor()
@@ -180,7 +177,7 @@ class AutoKnockoutTests(unittest.TestCase):
         self.assertEqual(events[0].action, "knockout")
         self.assertIn("set knocked_out = true", query_texts(cur)[0])
 
-    def test_zero_checkin_challenger_is_knocked_out_without_using_mulligan(self):
+    def test_zero_checkin_challenger_gets_mulligan_on_first_day(self):
         cur = FakeCursor()
 
         events = apply_auto_knockout_for_week(
@@ -189,12 +186,8 @@ class AutoKnockoutTests(unittest.TestCase):
             [participant(checkin_count=0)],
         )
 
-        self.assertEqual(len(events), 1)
-        self.assertEqual(events[0].action, "knockout")
-        self.assertEqual(len(cur.queries), 1)
-        self.assertIn("set knocked_out = true", query_texts(cur)[0])
-        self.assertNotIn("insert into checkins", query_texts(cur)[0])
-        self.assertNotIn("set mulligan", query_texts(cur)[0])
+        self.assertEqual(events[0].action, "mulligan")
+        self.assertEqual(events[0].mulligan_day, "Monday")
 
     def test_green_week_requires_five_checkins(self):
         cur = FakeCursor()


### PR DESCRIPTION
## Summary
- revert PR #58 from upstream
- keep the mulligan enforcement fix under development on the origin fork

## Test plan
- [x] Exact revert of PR #58


Made with [Cursor](https://cursor.com)