### PR TITLE
Run auto-knockout daily with mid-week doom detection

### DIFF
--- a/src/auto_knockout.py
+++ b/src/auto_knockout.py
@@ -138,7 +138,7 @@ def get_current_challenge_week(cur):
     return cur.fetchone()
 
 
-def get_participants_for_week(cur, challenge_id, challenge_week_id):
+def get_participants_for_week(cur, challenge_id, challenge_week_id, run_day):
     cur.execute(
         """
         select
@@ -147,7 +147,6 @@ def get_participants_for_week(cur, challenge_id, challenge_week_id):
             ch.discord_id,
             ch.tz,
             cc.mulligan,
-            mulligan_checkin.challenge_week_id as mulligan_challenge_week_id,
             count(distinct c.day_of_week) filter (
                 where c.tier != 'T0'
             ) as checkin_count,
@@ -156,10 +155,13 @@ def get_participants_for_week(cur, challenge_id, challenge_week_id):
                     where c.tier != 'T0'
                 ),
                 null
-            ) as checked_in_days
+            ) as checked_in_days,
+            coalesce(
+                bool_or(c.tier != 'T0' and c.day_of_week = %s),
+                false
+            ) as current_day_checked_in
         from challenger_challenges cc
         join challengers ch on ch.id = cc.challenger_id
-        left join checkins mulligan_checkin on mulligan_checkin.id = cc.mulligan
         left join checkins c on
             c.challenger = ch.id
             and c.challenge_week_id = %s
@@ -172,11 +174,10 @@ def get_participants_for_week(cur, challenge_id, challenge_week_id):
             ch.name,
             ch.discord_id,
             ch.tz,
-            cc.mulligan,
-            mulligan_checkin.challenge_week_id
+            cc.mulligan
         order by ch.name;
         """,
-        (challenge_week_id, challenge_id),
+        (run_day, challenge_week_id, challenge_id),
     )
     return cur.fetchall()
 
@@ -270,23 +271,31 @@ def knock_out_challenger(cur, participant, challenge_week):
     )
 
 
-def apply_auto_knockout_for_week(cur, challenge_week, participants):
+def apply_auto_knockout_for_week(cur, challenge_week, participants, run_date):
     required_checkins = required_checkins_for_week(challenge_week.green)
+    remaining_days = remaining_week_days(run_date, challenge_week.end)
+    run_day = run_date.strftime("%A")
     events = []
 
     for participant in participants:
         checkin_count = participant.checkin_count or 0
-        if checkin_count >= required_checkins:
+        needed_checkins = required_checkins - checkin_count
+        effective_remaining_days = effective_remaining_week_days(
+            remaining_days,
+            run_day,
+            participant.current_day_checked_in,
+        )
+
+        # Still mathematically able to meet the requirement by checking in
+        # every remaining day: no action.
+        if needed_checkins <= len(effective_remaining_days):
             continue
 
-        if (
-            participant.mulligan is not None
-            and getattr(participant, "mulligan_challenge_week_id", None)
-            == challenge_week.challenge_week_id
-        ):
-            continue
+        # A mulligan is worth exactly one check-in, so it only helps if it
+        # brings the week back within reach.
+        mulligan_can_save = needed_checkins - 1 <= len(effective_remaining_days)
 
-        if participant.mulligan is None:
+        if participant.mulligan is None and mulligan_can_save:
             mulligan_id, mulligan_day = insert_mulligan(cur, participant, challenge_week)
             events.append(
                 AutoKnockoutEvent(
@@ -342,8 +351,10 @@ def build_auto_knockout_alerts_for_week(challenge_week, run_date, participants):
         if len(effective_remaining_days) == 0:
             continue
 
+        # Exactly-doomed-unless-perfect is warning territory; anything worse
+        # (needed > remaining) is handled by the knockout path instead.
         needed_checkins = required_checkins - checkin_count
-        if needed_checkins < len(effective_remaining_days):
+        if needed_checkins != len(effective_remaining_days):
             continue
 
         if not should_send_first_no_slack_warning(
@@ -419,28 +430,61 @@ def build_auto_knockout_reconciliation_message(events):
     return "\n\n".join(sections)
 
 
+def build_auto_knockout_daily_message(action_events, warning_events):
+    sections = []
+
+    reconciliation_message = build_auto_knockout_reconciliation_message(action_events)
+    if reconciliation_message is not None:
+        sections.append(reconciliation_message)
+
+    alert_message = build_auto_knockout_alert_message(warning_events)
+    if alert_message is not None:
+        sections.append(alert_message)
+
+    if len(sections) == 0:
+        return None
+
+    return "\n\n".join(sections)
+
+
 def run_auto_knockout():
     from helpers import with_psycopg
 
     def fn(conn, cur):
-        challenge_week = get_previous_challenge_week(cur)
-        if challenge_week is None:
-            logging.info("Auto-knockout skipped: no completed challenge week")
-            return []
+        run_date = datetime.now(tz=ZoneInfo("America/New_York")).date()
+        events = []
 
-        if challenge_week.bye_week:
-            logging.info(
-                "Auto-knockout skipped: challenge week %s is a bye week",
+        # The week that ended yesterday (if any) catches final-day failures
+        # that were never mathematically doomed mid-week; the current week
+        # catches challengers who can no longer meet the requirement.
+        weeks = [
+            ("previous", get_previous_challenge_week(cur)),
+            ("current", get_current_challenge_week(cur)),
+        ]
+
+        for label, challenge_week in weeks:
+            if challenge_week is None:
+                logging.info("Auto-knockout skipped: no %s challenge week", label)
+                continue
+
+            if challenge_week.bye_week:
+                logging.info(
+                    "Auto-knockout skipped: challenge week %s is a bye week",
+                    challenge_week.challenge_week_id,
+                )
+                continue
+
+            participants = get_participants_for_week(
+                cur,
+                challenge_week.challenge_id,
                 challenge_week.challenge_week_id,
+                run_date.strftime("%A"),
             )
-            return []
+            events.extend(
+                apply_auto_knockout_for_week(cur, challenge_week, participants, run_date)
+            )
 
-        participants = get_participants_for_week(
-            cur,
-            challenge_week.challenge_id,
-            challenge_week.challenge_week_id,
-        )
-        return apply_auto_knockout_for_week(cur, challenge_week, participants)
+        return events
 
     return with_psycopg(fn)
 

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -2,8 +2,7 @@ from rq import cron
 from helpers import fetchall
 from green import determine_if_green
 from auto_knockout import (
-    build_auto_knockout_alert_message,
-    build_auto_knockout_reconciliation_message,
+    build_auto_knockout_daily_message,
     run_auto_knockout,
     run_auto_knockout_alerts,
 )
@@ -116,36 +115,29 @@ cron.register(challenge_start_message, queue_name="cron", cron="0 14 * * 1")
 
 async def auto_knockout():
     logging.info("Running auto-knockout")
-    events = run_auto_knockout()
-    message = build_auto_knockout_reconciliation_message(events)
-    if message is not None:
-        channel = await get_channel()
-        if channel is None:
-            logging.warning("Cannot send auto-knockout message: channel not found")
-        else:
-            await channel.send(message)
-    logging.info("Auto-knockout completed with %s state changes", len(events))
+    # Reconciliation commits first so warnings are computed from
+    # post-reconciliation state (fresh mulligans counted, fresh
+    # knockouts excluded).
+    action_events = run_auto_knockout()
+    warning_events = run_auto_knockout_alerts()
+    logging.info(
+        "Auto-knockout completed with %s state changes and %s warnings",
+        len(action_events),
+        len(warning_events),
+    )
 
-
-cron.register(auto_knockout, queue_name="cron", cron="5 14 * * 1")
-
-
-async def auto_knockout_alerts():
-    logging.info("Running auto-knockout alerts")
-    events = run_auto_knockout_alerts()
-    message = build_auto_knockout_alert_message(events)
+    message = build_auto_knockout_daily_message(action_events, warning_events)
     if message is None:
-        logging.info("Auto-knockout alerts completed with no warnings")
         return
 
     channel = await get_channel()
     if channel is None:
-        logging.warning("Cannot send auto-knockout alert message: channel not found")
+        logging.warning("Cannot send auto-knockout message: channel not found")
         return
     await channel.send(message)
 
 
-cron.register(auto_knockout_alerts, queue_name="cron", cron="10 14 * * *")
+cron.register(auto_knockout, queue_name="cron", cron="5 14 * * *")
 
 # def check_mulligans():
 #    logging.info("checking for mulligans")

--- a/tests/test_auto_knockout.py
+++ b/tests/test_auto_knockout.py
@@ -1,10 +1,11 @@
 import os
 import sys
 import unittest
-from datetime import date
+from datetime import date, datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
+from zoneinfo import ZoneInfo
 
 
 os.environ.setdefault("DB_CONNECT_STRING", "postgresql://postgres:password@localhost/projects")
@@ -16,6 +17,7 @@ from auto_knockout import (
     apply_auto_knockout_for_week,
     build_auto_knockout_alert_message,
     build_auto_knockout_alerts_for_week,
+    build_auto_knockout_daily_message,
     build_auto_knockout_reconciliation_message,
     first_missed_day,
     get_alert_participants_for_week,
@@ -37,6 +39,10 @@ def challenge_week(green=False, bye_week=False):
     )
 
 
+# The morning after the test week (Mon Apr 27 - Sun May 3) has ended.
+WEEK_END_RUN_DATE = date(2026, 5, 4)
+
+
 def participant(
     *,
     checkin_count,
@@ -45,7 +51,6 @@ def participant(
     challenger_id=1,
     name="Test User",
     current_day_checked_in=False,
-    mulligan_challenge_week_id=None,
 ):
     return SimpleNamespace(
         id=challenger_id,
@@ -56,7 +61,6 @@ def participant(
         checkin_count=checkin_count,
         checked_in_days=checked_in_days or [],
         current_day_checked_in=current_day_checked_in,
-        mulligan_challenge_week_id=mulligan_challenge_week_id,
     )
 
 
@@ -102,18 +106,20 @@ class AutoKnockoutTests(unittest.TestCase):
             cur,
             challenge_week(),
             [participant(checkin_count=2, checked_in_days=["Monday", "Tuesday"])],
+            WEEK_END_RUN_DATE,
         )
 
         self.assertEqual(events, [])
         self.assertEqual(cur.queries, [])
 
-    def test_mulligan_inserted_when_below_requirement_without_mulligan(self):
+    def test_mulligan_inserted_when_one_short_at_week_end_without_mulligan(self):
         cur = FakeCursor()
 
         events = apply_auto_knockout_for_week(
             cur,
             challenge_week(),
             [participant(checkin_count=1, checked_in_days=["Monday"])],
+            WEEK_END_RUN_DATE,
         )
 
         self.assertEqual(len(events), 1)
@@ -131,6 +137,7 @@ class AutoKnockoutTests(unittest.TestCase):
             cur,
             challenge_week(),
             [participant(checkin_count=1, checked_in_days=["Monday"], mulligan=99)],
+            WEEK_END_RUN_DATE,
         )
 
         self.assertEqual(len(events), 1)
@@ -138,9 +145,11 @@ class AutoKnockoutTests(unittest.TestCase):
         self.assertEqual(events[0].discord_id, "1001")
         self.assertIn("set knocked_out = true", query_texts(cur)[0])
 
-    def test_rerun_skips_challenger_with_mulligan_from_same_week(self):
+    def test_challenger_doomed_again_after_same_week_mulligan_is_knocked_out(self):
         cur = FakeCursor()
 
+        # Mulligan already applied this week counted as one check-in; the
+        # challenger still failed the requirement, so they are knocked out.
         events = apply_auto_knockout_for_week(
             cur,
             challenge_week(),
@@ -149,45 +158,31 @@ class AutoKnockoutTests(unittest.TestCase):
                     checkin_count=1,
                     checked_in_days=["Monday"],
                     mulligan=123,
-                    mulligan_challenge_week_id=10,
                 )
             ],
-        )
-
-        self.assertEqual(events, [])
-        self.assertEqual(cur.queries, [])
-
-    def test_prior_week_mulligan_still_allows_knockout(self):
-        cur = FakeCursor()
-
-        events = apply_auto_knockout_for_week(
-            cur,
-            challenge_week(),
-            [
-                participant(
-                    checkin_count=1,
-                    checked_in_days=["Monday"],
-                    mulligan=123,
-                    mulligan_challenge_week_id=9,
-                )
-            ],
+            WEEK_END_RUN_DATE,
         )
 
         self.assertEqual(len(events), 1)
         self.assertEqual(events[0].action, "knockout")
         self.assertIn("set knocked_out = true", query_texts(cur)[0])
 
-    def test_zero_checkin_challenger_gets_mulligan_on_first_day(self):
+    def test_zero_checkin_challenger_knocked_out_when_mulligan_cannot_save(self):
         cur = FakeCursor()
 
+        # 0/2 at week end: a single mulligan check-in cannot save the week,
+        # so the challenger is knocked out without spending the mulligan.
         events = apply_auto_knockout_for_week(
             cur,
             challenge_week(),
             [participant(checkin_count=0)],
+            WEEK_END_RUN_DATE,
         )
 
-        self.assertEqual(events[0].action, "mulligan")
-        self.assertEqual(events[0].mulligan_day, "Monday")
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].action, "knockout")
+        self.assertEqual(len(cur.queries), 1)
+        self.assertIn("set knocked_out = true", query_texts(cur)[0])
 
     def test_green_week_requires_five_checkins(self):
         cur = FakeCursor()
@@ -202,10 +197,136 @@ class AutoKnockoutTests(unittest.TestCase):
                     mulligan=99,
                 )
             ],
+            WEEK_END_RUN_DATE,
         )
 
         self.assertEqual(events[0].action, "knockout")
         self.assertEqual(events[0].required_checkins, 5)
+
+    def test_midweek_no_action_when_still_savable(self):
+        cur = FakeCursor()
+
+        # Saturday with 0/2: checking in Saturday and Sunday still works.
+        events = apply_auto_knockout_for_week(
+            cur,
+            challenge_week(),
+            [participant(checkin_count=0)],
+            date(2026, 5, 2),
+        )
+
+        self.assertEqual(events, [])
+        self.assertEqual(cur.queries, [])
+
+    def test_midweek_mulligan_applied_when_doomed_but_savable_by_mulligan(self):
+        cur = FakeCursor()
+
+        # Sunday with 0/2: only one day remains, so the challenger is doomed,
+        # but the mulligan (one check-in) puts the week back within reach.
+        events = apply_auto_knockout_for_week(
+            cur,
+            challenge_week(),
+            [participant(checkin_count=0)],
+            date(2026, 5, 3),
+        )
+
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].action, "mulligan")
+        self.assertEqual(events[0].mulligan_day, "Monday")
+        self.assertIn("insert into checkins", query_texts(cur)[0])
+
+    def test_midweek_knockout_when_doomed_with_mulligan_spent(self):
+        cur = FakeCursor()
+
+        # Green week Friday with 1/5: four needed, three days remain.
+        events = apply_auto_knockout_for_week(
+            cur,
+            challenge_week(green=True),
+            [participant(checkin_count=1, checked_in_days=["Monday"], mulligan=99)],
+            date(2026, 5, 1),
+        )
+
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].action, "knockout")
+        self.assertIn("set knocked_out = true", query_texts(cur)[0])
+
+    def test_midweek_knockout_when_mulligan_cannot_save_week(self):
+        cur = FakeCursor()
+
+        # Green week Friday with 0/5: five needed, three days remain, and a
+        # mulligan only covers one, so knock out without inserting a mulligan.
+        events = apply_auto_knockout_for_week(
+            cur,
+            challenge_week(green=True),
+            [participant(checkin_count=0)],
+            date(2026, 5, 1),
+        )
+
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].action, "knockout")
+        self.assertEqual(len(cur.queries), 1)
+        self.assertIn("set knocked_out = true", query_texts(cur)[0])
+
+    def test_midweek_current_day_checkin_counts_toward_remaining(self):
+        cur = FakeCursor()
+
+        # Green week Saturday with 3/5 and no check-in yet today: Saturday and
+        # Sunday remain, so the week is still savable.
+        events = apply_auto_knockout_for_week(
+            cur,
+            challenge_week(green=True),
+            [
+                participant(
+                    checkin_count=3,
+                    checked_in_days=["Monday", "Tuesday", "Wednesday"],
+                    mulligan=99,
+                )
+            ],
+            date(2026, 5, 2),
+        )
+
+        self.assertEqual(events, [])
+
+        # Same Saturday, but today's check-in is already in the count: only
+        # Sunday remains for the two still needed, so the challenger is doomed.
+        events = apply_auto_knockout_for_week(
+            cur,
+            challenge_week(green=True),
+            [
+                participant(
+                    checkin_count=3,
+                    checked_in_days=["Monday", "Tuesday", "Saturday"],
+                    mulligan=99,
+                    current_day_checked_in=True,
+                )
+            ],
+            date(2026, 5, 2),
+        )
+
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].action, "knockout")
+
+    def test_midweek_mulligan_counts_as_single_checkin_then_knockout(self):
+        cur = FakeCursor()
+
+        # Green week: mulligan already applied this week brought the count to
+        # 2/5. On Saturday only two days remain for the three still needed,
+        # so the challenger is knocked out despite the same-week mulligan.
+        events = apply_auto_knockout_for_week(
+            cur,
+            challenge_week(green=True),
+            [
+                participant(
+                    checkin_count=2,
+                    checked_in_days=["Monday", "Tuesday"],
+                    mulligan=50,
+                )
+            ],
+            date(2026, 5, 2),
+        )
+
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].action, "knockout")
+        self.assertIn("set knocked_out = true", query_texts(cur)[0])
 
     def test_first_missed_day_skips_checked_in_days(self):
         day_name, missing_date = first_missed_day(
@@ -219,21 +340,22 @@ class AutoKnockoutTests(unittest.TestCase):
     def test_participant_query_skips_knocked_out_challengers(self):
         cur = FakeCursor()
 
-        get_participants_for_week(cur, challenge_id=1, challenge_week_id=10)
+        get_participants_for_week(
+            cur, challenge_id=1, challenge_week_id=10, run_day="Saturday"
+        )
 
         self.assertIn("ch.discord_id", query_texts(cur)[0])
         self.assertIn("cc.knocked_out = false", query_texts(cur)[0])
 
-    def test_participant_query_exposes_mulligan_challenge_week(self):
+    def test_participant_query_exposes_current_day_checkin(self):
         cur = FakeCursor()
 
-        get_participants_for_week(cur, challenge_id=1, challenge_week_id=10)
-
-        self.assertIn(
-            "mulligan_checkin.challenge_week_id as mulligan_challenge_week_id",
-            query_texts(cur)[0],
+        get_participants_for_week(
+            cur, challenge_id=1, challenge_week_id=10, run_day="Saturday"
         )
-        self.assertIn("left join checkins mulligan_checkin", query_texts(cur)[0])
+
+        self.assertIn("current_day_checked_in", query_texts(cur)[0])
+        self.assertEqual(cur.queries[0][1][0], "Saturday")
 
     def test_previous_challenge_week_only_targets_week_ending_yesterday(self):
         cur = FakeCursor()
@@ -258,7 +380,55 @@ class AutoKnockoutTests(unittest.TestCase):
             events = run_auto_knockout()
 
         self.assertEqual(events, [])
-        self.assertEqual(len(captured["cur"].queries), 1)
+        # Only the two week-lookup queries run; participants are never fetched.
+        self.assertEqual(len(captured["cur"].queries), 2)
+
+    def test_run_auto_knockout_processes_previous_and_current_week(self):
+        today = datetime.now(tz=ZoneInfo("America/New_York")).date()
+        previous_week = SimpleNamespace(
+            challenge_id=1,
+            challenge_week_id=9,
+            start=today - timedelta(days=7),
+            end=today - timedelta(days=1),
+            green=False,
+            bye_week=False,
+        )
+        current_week = SimpleNamespace(
+            challenge_id=1,
+            challenge_week_id=10,
+            start=today,
+            end=today + timedelta(days=6),
+            green=False,
+            bye_week=False,
+        )
+
+        # Previous week ended one check-in short: mulligan applies.
+        # Current week just started: nobody is doomed yet.
+        previous_participants = [participant(checkin_count=1, checked_in_days=[])]
+        current_participants = [participant(checkin_count=0)]
+
+        cur = FakeCursor()
+
+        def fake_with_psycopg(fn):
+            return fn(None, cur)
+
+        with patch.dict(
+            sys.modules,
+            {"helpers": SimpleNamespace(with_psycopg=fake_with_psycopg)},
+        ), patch(
+            "auto_knockout.get_previous_challenge_week", return_value=previous_week
+        ), patch(
+            "auto_knockout.get_current_challenge_week", return_value=current_week
+        ), patch(
+            "auto_knockout.get_participants_for_week",
+            side_effect=[previous_participants, current_participants],
+        ) as participants_mock:
+            events = run_auto_knockout()
+
+        self.assertEqual(participants_mock.call_count, 2)
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].action, "mulligan")
+        self.assertEqual(events[0].challenge_week_id, 9)
 
     def test_normal_week_alert_when_no_mulligan_challenger_has_no_slack(self):
         events = build_auto_knockout_alerts_for_week(
@@ -373,6 +543,62 @@ class AutoKnockoutTests(unittest.TestCase):
         message = build_auto_knockout_alert_message(events)
 
         self.assertIn("to avoid using a mulligan or being knocked out", message)
+
+    def test_alert_still_sent_after_same_week_mulligan(self):
+        # A same-week mulligan no longer forgives the week: with 1/2 (the
+        # mulligan check-in) and only Sunday left, the challenger is warned.
+        events = build_auto_knockout_alerts_for_week(
+            challenge_week(),
+            date(2026, 5, 3),
+            [participant(checkin_count=1, checked_in_days=["Monday"], mulligan=50)],
+        )
+
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].action, "warning")
+        self.assertEqual(events[0].remaining_checkin_days, ("Sunday",))
+        self.assertFalse(events[0].has_mulligan_available)
+
+    def test_daily_message_combines_actions_and_warnings(self):
+        action_events = [
+            AutoKnockoutEvent(
+                action="knockout",
+                challenge_id=1,
+                challenger_id=1,
+                name="Knocked Out User",
+                required_checkins=2,
+                checkin_count=0,
+                challenge_week_id=10,
+                discord_id="111",
+            )
+        ]
+        warning_events = build_auto_knockout_alerts_for_week(
+            challenge_week(),
+            date(2026, 5, 2),
+            [participant(checkin_count=0, challenger_id=2, mulligan=99)],
+        )
+
+        message = build_auto_knockout_daily_message(action_events, warning_events)
+
+        self.assertIn("## Knockouts", message)
+        self.assertIn("<@111>", message)
+        self.assertIn("## Knockout warnings", message)
+        self.assertIn("<@1002>", message)
+        self.assertLess(message.index("## Knockouts"), message.index("## Knockout warnings"))
+
+    def test_daily_message_with_only_warnings(self):
+        warning_events = build_auto_knockout_alerts_for_week(
+            challenge_week(),
+            date(2026, 5, 2),
+            [participant(checkin_count=0, mulligan=99)],
+        )
+
+        message = build_auto_knockout_daily_message([], warning_events)
+
+        self.assertIn("## Knockout warnings", message)
+        self.assertNotIn("## Knockouts\n", message)
+
+    def test_daily_message_none_when_no_events(self):
+        self.assertIsNone(build_auto_knockout_daily_message([], []))
 
     def test_reconciliation_message_mentions_mulligan_used(self):
         message = build_auto_knockout_reconciliation_message(


### PR DESCRIPTION
## Summary
- Convert auto-knockout from a weekly Monday reconciliation to a daily task that applies mulligans/knockouts as soon as a challenger is mathematically doomed (`needed > remaining days`).
- Treat a mulligan as exactly one check-in: apply it mid-week only when it makes the week savable again; otherwise knock out. A this-week mulligan no longer forgives the rest of the week.
- Merge knockout actions and warnings into one daily Discord message, with warnings computed from post-reconciliation state (`needed == remaining`).

## Test plan
- [ ] Run `python3 tests/test_auto_knockout.py`
- [ ] Confirm cron registers `auto_knockout` at `5 14 * * *` and the separate alerts cron is removed
- [ ] On a test week, verify a challenger with no slack gets a warning, then a mulligan or knockout on the next doomed day
- [ ] Verify Monday still reconciles the week that ended Sunday for last-day failures


Made with [Cursor](https://cursor.com)