### PR TITLE
Reduce early-week medal spam with Opening Medal Roundup

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -16,6 +16,7 @@ import slash_commands.bmr
 from chart import checkin_chart, diamond_week_holders, red_week_holders, week_heat_map_from_checkins, write_og_image
 from rule_sets import calculate_total_score
 import medal_log
+from medal_roundup import should_suppress_medal_announcements
 from discord_bot import bot
 
 LOGLEVEL = os.environ.get("LOGLEVEL", "DEBUG").upper()
@@ -267,6 +268,13 @@ async def on_message(message):
         # Add reactions for all medals
         for medal in relevant_medals:
             await message.add_reaction(medal.medal_emoji)
+
+        # Suppress replies until after Opening Medal Roundup on challenge day 2.
+        if should_suppress_medal_announcements(challenge_week.start):
+            logging.info(
+                "DISCORD: skipping medal reply before opening roundup window ends"
+            )
+            return
         
         # Group medals by user, action type, and (for steals) the person they stole from
         grouped_medals = defaultdict(list)

--- a/src/medal_constants.py
+++ b/src/medal_constants.py
@@ -1,0 +1,31 @@
+# Shared medal display/constants with no DB dependencies.
+
+NON_STEALABLE_MEDALS = frozenset(
+    {"green", "red", "diamond", "gold", "first_to_green", "all_gold", "all_green"}
+)
+
+CHALLENGE_SCOPED_MEDALS = frozenset(
+    {
+        "highest_tier_challenge",
+        "earliest_for_challenge",
+        "latest_for_challenge",
+        "all_gold",
+        "all_green",
+    }
+)
+
+nice_medal_names = {
+    "highest_tier_challenge": "Highest Overall Tier",
+    "highest_tier_week": "Highest Weekly Tier",
+    "gold": "Gold Week",
+    "all_gold": "All Gold",
+    "first_to_green": "First to Green",
+    "green": "Green Week",
+    "red": "Red Week",
+    "diamond": "Diamond Week",
+    "all_green": "All Green",
+    "earliest_for_week": "Earliest Weekly Check-in",
+    "latest_for_week": "Latest Weekly Check-in",
+    "earliest_for_challenge": "Earliest Overall Check-in",
+    "latest_for_challenge": "Latest Overall Check-in",
+}

--- a/src/medal_roundup.py
+++ b/src/medal_roundup.py
@@ -1,0 +1,112 @@
+from datetime import datetime, time, timezone
+from zoneinfo import ZoneInfo
+
+from auto_knockout import format_natural_language_list
+from medal_constants import NON_STEALABLE_MEDALS, nice_medal_names
+
+ROUNDUP_TZ = ZoneInfo("America/New_York")
+# Matches tasks.py cron "0 14 * * *". Silence until one minute later so the
+# Opening Medal Roundup usually posts before live replies resume.
+ROUNDUP_CRON_UTC_HOUR = 14
+ROUNDUP_SILENCE_UNTIL_UTC = time(ROUNDUP_CRON_UTC_HOUR, 1)
+
+
+def _as_date(value):
+    if isinstance(value, datetime):
+        return value.date()
+    return value
+
+
+def challenge_day_index(week_start, today=None):
+    """0-based day index within the challenge week (NY calendar dates)."""
+    week_start = _as_date(week_start)
+    if today is None:
+        today = datetime.now(ROUNDUP_TZ).date()
+    else:
+        today = _as_date(today)
+    return (today - week_start).days
+
+
+def is_challenge_day_one(week_start, today=None):
+    """True when today is the first calendar day of the challenge week."""
+    return challenge_day_index(week_start, today) == 0
+
+
+def is_opening_roundup_day(week_start, today=None):
+    """True on challenge day 2 (the day the Opening Medal Roundup fires)."""
+    return challenge_day_index(week_start, today) == 1
+
+
+def should_suppress_medal_announcements(week_start, now=None):
+    """
+    Suppress live medal replies on challenge day 1, and on challenge day 2
+    before 14:01 UTC (one minute after the Opening Medal Roundup cron at 14:00 UTC).
+    Day index uses America/New_York calendar dates; the cutoff uses UTC to match cron.
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+    elif now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+
+    now_utc = now.astimezone(timezone.utc)
+    day = challenge_day_index(week_start, now.astimezone(ROUNDUP_TZ).date())
+    if day == 0:
+        return True
+    if day == 1 and now_utc.time() < ROUNDUP_SILENCE_UNTIL_UTC:
+        return True
+    return False
+
+
+def describe_medal(medal_name):
+    fallback = medal_name.replace("_", " ").replace("  ", " ").title()
+    return nice_medal_names.get(medal_name, fallback)
+
+
+def format_medal_display(medal_name, medal_emoji):
+    emoji = medal_emoji or ""
+    return f"{emoji} __**{describe_medal(medal_name)}**__".strip()
+
+
+def build_opening_medal_roundup_message(standings):
+    """
+    Build the Opening Medal Roundup Discord message.
+
+    Returns None when there are no medals to report.
+    Non-stealable medals use "earned"; stealable use "currently holds".
+    Earned always comes before currently holds for a given user.
+    """
+    if not standings:
+        return None
+
+    by_user = {}
+    user_order = []
+
+    for row in standings:
+        discord_id = str(row.discord_id)
+        if discord_id not in by_user:
+            by_user[discord_id] = {"earned": [], "holds": []}
+            user_order.append(discord_id)
+
+        display = format_medal_display(row.medal_name, row.medal_emoji)
+        if row.medal_name in NON_STEALABLE_MEDALS:
+            by_user[discord_id]["earned"].append(display)
+        else:
+            by_user[discord_id]["holds"].append(display)
+
+    lines = []
+    for discord_id in user_order:
+        earned = by_user[discord_id]["earned"]
+        holds = by_user[discord_id]["holds"]
+        parts = []
+        if earned:
+            parts.append(f"earned {format_natural_language_list(earned)}")
+        if holds:
+            parts.append(f"currently holds {format_natural_language_list(holds)}")
+        if not parts:
+            continue
+        lines.append(f"- <@{discord_id}> {', and '.join(parts)}.")
+
+    if not lines:
+        return None
+
+    return "## Opening Medal Roundup\n" + "\n".join(lines)

--- a/src/medals.py
+++ b/src/medals.py
@@ -1,5 +1,10 @@
 from helpers import *
 import logging
+from medal_constants import (
+    CHALLENGE_SCOPED_MEDALS,
+    NON_STEALABLE_MEDALS,
+    nice_medal_names,
+)
 
 # Podium emoji constants
 PODIUM_EMOJIS = {
@@ -25,22 +30,8 @@ medal_metadata = {
     "latest_for_week": {"group": "D", "difficulty": 2},
 }
 
-# Nice display names for medals
-nice_medal_names = {
-    "highest_tier_challenge": "Highest Overall Tier",
-    "highest_tier_week": "Highest Weekly Tier",
-    "gold": "Gold Week",
-    "all_gold": "All Gold",
-    "first_to_green": "First to Green",
-    "green": "Green Week",
-    "red": "Red Week",
-    "diamond": "Diamond Week",
-    "all_green": "All Green",
-    "earliest_for_week": "Earliest Weekly Check-in",
-    "latest_for_week": "Latest Weekly Check-in",
-    "earliest_for_challenge": "Earliest Overall Check-in",
-    "latest_for_challenge": "Latest Overall Check-in",
-}
+# Re-export for existing imports: from medals import nice_medal_names, NON_STEALABLE_MEDALS
+
 
 # all medal queries return
 # name, tier, checkin_id, challenge_week_id, time, medal_name, medal_emoji
@@ -158,13 +149,66 @@ insert into medals
     with_psycopg(insert_all_medals)
 
 
+def get_current_week_medal_standings(challenge_id, challenge_week_id):
+    """
+    Current medal holders for the opening roundup.
+
+    Week-scoped medals: rows for this challenge week.
+    Challenge-scoped medals: current holders across the whole challenge
+    (so prior-week awards still appear as currently held).
+
+    Non-stealable medals: every recipient.
+    Stealable medals: only the latest holder per medal name.
+    """
+    non_stealable_list = ", ".join(f"'{m}'" for m in sorted(NON_STEALABLE_MEDALS))
+    challenge_scoped_list = ", ".join(
+        f"'{m}'" for m in sorted(CHALLENGE_SCOPED_MEDALS)
+    )
+    sql = f"""
+    WITH ranked_medals AS (
+        SELECT
+            m.medal AS medal_name,
+            m.emoji AS medal_emoji,
+            c.discord_id,
+            m.created_at,
+            ROW_NUMBER() OVER (
+                PARTITION BY
+                    m.medal,
+                    CASE
+                        WHEN m.medal IN ({non_stealable_list})
+                        THEN m.challenger_id
+                    END
+                ORDER BY m.created_at DESC
+            ) AS rn
+        FROM medals m
+        JOIN challengers c ON c.id = m.challenger_id
+        WHERE
+            (
+                m.medal IN ({challenge_scoped_list})
+                AND m.challenge_id = %s
+            )
+            OR (
+                m.medal NOT IN ({challenge_scoped_list})
+                AND m.challenge_week_id = %s
+            )
+    )
+    SELECT
+        medal_name,
+        medal_emoji,
+        discord_id
+    FROM ranked_medals
+    WHERE rn = 1
+    ORDER BY created_at, discord_id, medal_name;
+    """
+    return fetchall(sql, [challenge_id, challenge_week_id])
+
+
 def reconcile_medals(new_medals, current_medals):
     # green, gold, and first to green cannot be stolen
-    non_stealable = {"green", "red", "diamond", "gold", "first_to_green", "all_gold", "all_green"}
     medals = [
         {**m._asdict(), "steal": None}
         for m in new_medals
-        if m.medal_name in non_stealable
+        if m.medal_name in NON_STEALABLE_MEDALS
     ]
 
     latest_for_week_new = next(

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -139,6 +139,42 @@ async def auto_knockout():
 
 cron.register(auto_knockout, queue_name="cron", cron="5 14 * * *")
 
+
+async def opening_medal_roundup():
+    logging.info("Running opening medal roundup")
+    from base_queries import get_current_challenge_week
+    from medal_roundup import (
+        build_opening_medal_roundup_message,
+        is_opening_roundup_day,
+    )
+    from medals import get_current_week_medal_standings
+
+    challenge_week = get_current_challenge_week()
+    if challenge_week is None:
+        logging.info("No current challenge week; skipping opening medal roundup")
+        return
+
+    if not is_opening_roundup_day(challenge_week.start):
+        logging.info("Not challenge day 2; skipping opening medal roundup")
+        return
+
+    standings = get_current_week_medal_standings(
+        challenge_week.challenge_id, challenge_week.id
+    )
+    message = build_opening_medal_roundup_message(standings)
+    if message is None:
+        logging.info("No medals for opening roundup; skipping")
+        return
+
+    channel = await get_channel()
+    if channel is None:
+        logging.warning("Cannot send opening medal roundup: channel not found")
+        return
+    await channel.send(message)
+
+
+cron.register(opening_medal_roundup, queue_name="cron", cron="0 14 * * *")
+
 # def check_mulligans():
 #    logging.info("checking for mulligans")
 #    last_week_checkins = check_last_week_for_mulligan_necessity()

--- a/tests/test_medal_roundup.py
+++ b/tests/test_medal_roundup.py
@@ -1,0 +1,219 @@
+import os
+import sys
+import unittest
+from datetime import date, datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+
+
+os.environ.setdefault("DB_CONNECT_STRING", "postgresql://postgres:password@localhost/projects")
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from medal_roundup import (
+    ROUNDUP_TZ,
+    build_opening_medal_roundup_message,
+    is_challenge_day_one,
+    is_opening_roundup_day,
+    should_suppress_medal_announcements,
+)
+
+
+def standing(discord_id, medal_name, medal_emoji=""):
+    return SimpleNamespace(
+        discord_id=discord_id,
+        medal_name=medal_name,
+        medal_emoji=medal_emoji,
+    )
+
+
+def utc_dt(year, month, day, hour, minute=0):
+    return datetime(year, month, day, hour, minute, tzinfo=timezone.utc)
+
+
+def ny_dt(year, month, day, hour, minute=0):
+    return datetime(year, month, day, hour, minute, tzinfo=ROUNDUP_TZ)
+
+
+class TestIsChallengeDayOne(unittest.TestCase):
+    def test_first_day(self):
+        self.assertTrue(is_challenge_day_one(date(2026, 4, 27), date(2026, 4, 27)))
+
+    def test_second_day(self):
+        self.assertFalse(is_challenge_day_one(date(2026, 4, 27), date(2026, 4, 28)))
+
+
+class TestIsOpeningRoundupDay(unittest.TestCase):
+    def test_day_two_monday_start(self):
+        self.assertTrue(is_opening_roundup_day(date(2026, 4, 27), date(2026, 4, 28)))
+
+    def test_day_one_not_roundup_day(self):
+        self.assertFalse(is_opening_roundup_day(date(2026, 4, 27), date(2026, 4, 27)))
+
+    def test_day_three_not_roundup_day(self):
+        self.assertFalse(is_opening_roundup_day(date(2026, 4, 27), date(2026, 4, 29)))
+
+    def test_non_monday_week_start(self):
+        # Challenge week starts Wednesday; roundup day is Thursday.
+        self.assertTrue(is_opening_roundup_day(date(2026, 4, 29), date(2026, 4, 30)))
+        self.assertFalse(is_opening_roundup_day(date(2026, 4, 29), date(2026, 4, 28)))
+
+
+class TestShouldSuppressMedalAnnouncements(unittest.TestCase):
+    week_start = date(2026, 4, 27)  # Monday
+
+    def test_suppress_on_day_zero_any_utc_time(self):
+        self.assertTrue(
+            should_suppress_medal_announcements(
+                self.week_start, utc_dt(2026, 4, 27, 13, 0)
+            )
+        )
+        self.assertTrue(
+            should_suppress_medal_announcements(
+                self.week_start, utc_dt(2026, 4, 27, 15, 0)
+            )
+        )
+
+    def test_suppress_on_day_one_before_utc_cutoff(self):
+        self.assertTrue(
+            should_suppress_medal_announcements(
+                self.week_start, utc_dt(2026, 4, 28, 13, 59)
+            )
+        )
+        self.assertTrue(
+            should_suppress_medal_announcements(
+                self.week_start, utc_dt(2026, 4, 28, 14, 0)
+            )
+        )
+
+    def test_do_not_suppress_on_day_one_at_utc_cutoff(self):
+        self.assertFalse(
+            should_suppress_medal_announcements(
+                self.week_start, utc_dt(2026, 4, 28, 14, 1)
+            )
+        )
+
+    def test_do_not_suppress_on_day_one_after_utc_cutoff(self):
+        self.assertFalse(
+            should_suppress_medal_announcements(
+                self.week_start, utc_dt(2026, 4, 28, 14, 30)
+            )
+        )
+
+    def test_do_not_suppress_on_day_two_plus(self):
+        self.assertFalse(
+            should_suppress_medal_announcements(
+                self.week_start, utc_dt(2026, 4, 29, 8, 0)
+            )
+        )
+
+    def test_day_index_uses_ny_calendar_with_utc_cutoff(self):
+        # 2026-04-28 03:00 UTC is still 2026-04-27 23:00 EDT (day 0).
+        self.assertTrue(
+            should_suppress_medal_announcements(
+                self.week_start, utc_dt(2026, 4, 28, 3, 0)
+            )
+        )
+        # Same absolute time expressed in NY should agree.
+        self.assertTrue(
+            should_suppress_medal_announcements(
+                self.week_start, ny_dt(2026, 4, 27, 23, 0)
+            )
+        )
+
+
+class TestOpeningMedalRoundupMessage(unittest.TestCase):
+    def test_empty_standings_returns_none(self):
+        self.assertIsNone(build_opening_medal_roundup_message([]))
+        self.assertIsNone(build_opening_medal_roundup_message(None))
+
+    def test_earned_only(self):
+        message = build_opening_medal_roundup_message(
+            [
+                standing("1001", "green", "🟩"),
+                standing("1001", "first_to_green", "✳️"),
+            ]
+        )
+        self.assertEqual(
+            message,
+            "## Opening Medal Roundup\n"
+            "- <@1001> earned 🟩 __**Green Week**__ and ✳️ __**First to Green**__.",
+        )
+
+    def test_holds_only(self):
+        message = build_opening_medal_roundup_message(
+            [
+                standing("1002", "earliest_for_week", "☀️"),
+                standing("1002", "highest_tier_week", "💪"),
+            ]
+        )
+        self.assertEqual(
+            message,
+            "## Opening Medal Roundup\n"
+            "- <@1002> currently holds ☀️ __**Earliest Weekly Check-in**__ "
+            "and 💪 __**Highest Weekly Tier**__.",
+        )
+
+    def test_challenge_scoped_holds_alongside_week_medal(self):
+        message = build_opening_medal_roundup_message(
+            [
+                standing("1001", "green", "🟩"),
+                standing("1001", "highest_tier_challenge", "👑"),
+            ]
+        )
+        self.assertEqual(
+            message,
+            "## Opening Medal Roundup\n"
+            "- <@1001> earned 🟩 __**Green Week**__, "
+            "and currently holds 👑 __**Highest Overall Tier**__.",
+        )
+
+    def test_earned_before_currently_holds(self):
+        message = build_opening_medal_roundup_message(
+            [
+                standing("1001", "earliest_for_week", "☀️"),
+                standing("1001", "green", "🟩"),
+                standing("1001", "gold", "🏅"),
+                standing("1001", "highest_tier_week", "💪"),
+            ]
+        )
+        self.assertEqual(
+            message,
+            "## Opening Medal Roundup\n"
+            "- <@1001> earned 🟩 __**Green Week**__ and 🏅 __**Gold Week**__, "
+            "and currently holds ☀️ __**Earliest Weekly Check-in**__ "
+            "and 💪 __**Highest Weekly Tier**__.",
+        )
+
+    def test_multi_user_preserves_first_appearance_order(self):
+        message = build_opening_medal_roundup_message(
+            [
+                standing("1002", "latest_for_week", "🌙"),
+                standing("1001", "green", "🟩"),
+                standing("1003", "diamond", "💎"),
+            ]
+        )
+        self.assertEqual(
+            message,
+            "## Opening Medal Roundup\n"
+            "- <@1002> currently holds 🌙 __**Latest Weekly Check-in**__.\n"
+            "- <@1001> earned 🟩 __**Green Week**__.\n"
+            "- <@1003> earned 💎 __**Diamond Week**__.",
+        )
+
+    def test_three_earned_medals_use_oxford_comma(self):
+        message = build_opening_medal_roundup_message(
+            [
+                standing("1001", "green", "🟩"),
+                standing("1001", "gold", "🏅"),
+                standing("1001", "first_to_green", "✳️"),
+            ]
+        )
+        self.assertIn(
+            "earned 🟩 __**Green Week**__, 🏅 __**Gold Week**__, and ✳️ __**First to Green**__.",
+            message,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Suppress live medal reply spam on challenge day 1 and early day 2 (reactions still fire)
- Post a single Opening Medal Roundup on challenge day 2 via cron (`0 14 * * *` UTC)
- Centralize medal constants and add standings query + unit tests for day/suppress/message logic

## Test plan
- [ ] Run `python3 -m unittest tests.test_medal_roundup`
- [ ] On challenge day 1, confirm medal reactions still appear but no reply text
- [ ] On challenge day 2 before 14:01 UTC, confirm replies remain suppressed
- [ ] Confirm Opening Medal Roundup posts at ~14:00 UTC on day 2 with earned vs currently holds wording
- [ ] After 14:01 UTC on day 2+, confirm live medal replies resume normally


Made with [Cursor](https://cursor.com)